### PR TITLE
Remove default 'RTX 5080' value from search input

### DIFF
--- a/src/public/analytics.html
+++ b/src/public/analytics.html
@@ -207,7 +207,7 @@
       // Pre-populate with RTX 5080 as example
       const searchInput = document.getElementById('searchInput');
       if (searchInput) {
-        searchInput.value = 'RTX 5080';
+        // searchInput.value = '';
       }
     });
   </script>

--- a/src/public/js/analytics.js
+++ b/src/public/js/analytics.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', function() {
   initializeSearch();
 
   // Pre-populate with RTX 5080 as example
-  document.getElementById('searchInput').value = 'RTX 5080';
+  document.getElementById('searchInput').value = '';
 });
 
 // Current date/time display


### PR DESCRIPTION
Cleared the pre-populated value in the search input field on the analytics page, so it no longer defaults to 'RTX 5080'. This provides a blank search field for users by default.